### PR TITLE
Add connection ID to stream client data. Add stream relay emm processing (AU)

### DIFF
--- a/OSEmu.c
+++ b/OSEmu.c
@@ -450,6 +450,7 @@ int main(int argc, char**argv)
 			break;
 		case 'e':
 			requestau = 1;
+			emu_stream_emm_enabled = 1;
 			break;
 		case 'i':
 			exit(0);

--- a/README
+++ b/README
@@ -142,6 +142,17 @@ Keys in SoftCam.Key:
 
 	Multiple UA keys are allowed for each group and each UA will update ALL ecm keys in the group.
 
+	NOTE: in order to work, the ecm keys must be "seeded" in the file for each SID you want to update since the UA has no information about sids. 
+	So to add a key that is unknown, enter a dummy key to get updated, for example:
+
+	P 00010004 00 00000000000000000
+	P 00010004 01 00000000000000000
+
+	Also note: Duplicate powervu keys are no longer allowed (unnecessary since duplicate SIDs should now have a unique group ID.) 
+	So, if there are any duplicates, only the last key in the file will be used. 
+	This also means that as new keys are found and appended to the file, they will automatically replace earlier keys.
+
+
 For PowerVU the Stream Relay must be used:
 
 IMPORTANT:

--- a/README
+++ b/README
@@ -1,3 +1,5 @@
+!!! W A R N I N G !!!! SoftCam.Key file format changed for PowerVu keys! See Below.
+
 OSEmu
 ======
 
@@ -106,19 +108,39 @@ PowerVU config
 ==============
 
 Keys in SoftCam.Key:
-	P <srvid> <nb> <key>
-	example:
-	P 1234 01 11223344556677
 
-	For channels with same srvid the correct key will be detected automatically:
-	P 1234 01 11223344556677
-	P 1234 01 11223344556677
-	P 1234 01 11223344556677
+	P <groupid><srvid> <nb> <key>
+	Where:	groupid = any 4 hex digits signifying unique group for all channels using the same keys.
+			(Leading zeros not necessarry, but makes viewing the file easier...)
+		srvid = SID (Service ID) of channel in hex with leading zeros to make 4 hex digits.
+		nb = key number (00/01)
+		key = ecm key
+
+	example groupid=0x1, sid=0x1234, keys 00 and 01:
+	P 00011234 00 11223344556677
+	P 011234 01 22334455667788
+
+	example groupid=0x2, sid=0x34, keys 00 and 01:
+	P 00020034 00 00112233445566
+	P 0020034 01 00223344556677
+
+	For channels with the same srvid the correct key will be detected automatically, but each key needs a unique groupid.
+
+	P 009E0234 01 11223344556677
+	P 00040234 01 22334455667788
+	P 013E0234 01 33445566778899
 	
+	WARNING - duplicate <groupid><srvid> are not allowed anymore - only the last instance will be used!
+
 	AU keys:
-	P <srvid> <UA> <key>
+	P <groupid> <UA> <key>
 	example:
-	P 1234 11223344 11223344556677
+	P 009E 11223344 11223344556677
+	P 009E 44332211 22334455667788
+	P 0004 22334455 33445566778899
+	P 013E 00112233 00112233445566
+
+	Multiple UA keys are allowed for each group and each UA will update ALL ecm keys in the group.
 
 For PowerVU the Stream Relay must be used:
 

--- a/module-emulator-osemu.c
+++ b/module-emulator-osemu.c
@@ -3933,7 +3933,7 @@ static int8_t PowervuEMM(uint8_t *emm, uint32_t *keysAdded)
 	snprintf(keyName, EMU_MAX_CHAR_KEYNAME, "%.8X", uniqueAddress);
 	if(!GetPowervuEmmKey(emmKey, 0, keyName, 7, 0, &channelId))
 	{
-		cs_log("[Emu] EMM eror: AU key for UA %s is missing", keyName);
+		cs_log_dbg(D_EMM,"[Emu] EMM eror: AU key for UA %s is missing", keyName);
 		return 2;
 	}
 
@@ -4218,7 +4218,7 @@ int8_t ProcessEMM(uint16_t caid, uint32_t provider, const uint8_t *emm, uint32_t
 	}
 
 	if(result != 0) {
-		cs_log("[Emu] EMM failed: %s", GetProcessEMMErrorReason(result));
+		cs_log_dbg(D_EMM,"[Emu] EMM failed: %s", GetProcessEMMErrorReason(result));
 	}
 
 	return result;

--- a/module-emulator-osemu.h
+++ b/module-emulator-osemu.h
@@ -58,8 +58,13 @@
 	6  CW checksum error
 	7  Out of memory
 	*/
+#ifdef WITH_EMU
 	int8_t ProcessECM(int16_t ecmDataLen, uint16_t caid, uint32_t provider, const uint8_t *ecm,
-					  uint8_t *dw, uint16_t srvid, uint16_t ecmpid);
+				  uint8_t *dw, uint16_t srvid, uint16_t ecmpid, EXTENDED_CW* cw_ex);
+#else
+	int8_t ProcessECM(int16_t ecmDataLen, uint16_t caid, uint32_t provider, const uint8_t *ecm,
+				  uint8_t *dw, uint16_t srvid, uint16_t ecmpid);
+#endif
 
 	const char* GetProcessECMErrorReason(int8_t result);
 
@@ -101,7 +106,7 @@
 #define PVU_CW_VBI 7	// Vertical Blanking Interval
 
 #ifdef WITH_EMU
-	int8_t PowervuECM(uint8_t *ecm, uint8_t *dw, uint16_t srvid, emu_stream_client_key_data *cdata);
+	int8_t PowervuECM(uint8_t *ecm, uint8_t *dw, uint16_t srvid, emu_stream_client_key_data *cdata, EXTENDED_CW* cw_ex);
 #else
 	int8_t PowervuECM(uint8_t *ecm, uint8_t *dw, emu_stream_client_key_data *cdata);
 #endif

--- a/module-emulator-stream.c
+++ b/module-emulator-stream.c
@@ -25,6 +25,7 @@ char emu_stream_source_host[256] = {"127.0.0.1"};
 int32_t emu_stream_source_port = 8001;
 char *emu_stream_source_auth = NULL;
 int32_t emu_stream_relay_port = 17999;
+int8_t emu_stream_emm_enabled = 0;
 uint32_t cluster_size = 50;
 
 static uint8_t emu_stream_server_mutex_init = 0;
@@ -317,7 +318,7 @@ static void ParseTSPackets(emu_stream_client_data *data, uint8_t *stream_buf, ui
 		if(packetSize-offset < 1)
 			{ continue; }
 		
-		if( pid == 0x01 && !data->emm_pid ) // CAT 
+		if( pid == 0x01 && emu_stream_emm_enabled && !data->emm_pid ) // CAT 
 		{
 			cptr = stream_buf+i+offset;
 			j = 0;

--- a/module-emulator-stream.c
+++ b/module-emulator-stream.c
@@ -182,7 +182,7 @@ static void ParsePATData(emu_stream_client_data *cdata)
 		if(cdata->srvid == srvid)
 		{
 			cdata->pmt_pid = b2i(2, data+i+2) & 0x1FFF;
-			cs_log_dbg(D_READER, "[Emu] stream %i found pmt pid: %X",cdata->connid, cdata->pmt_pid);
+			cs_log_dbg(D_READER, "[Emu] stream %i found pmt  pid : 0x%04X (%i)",cdata->connid, cdata->pmt_pid, cdata->pmt_pid);
 			break;
 		}
 	}
@@ -222,7 +222,7 @@ static void ParsePMTData(emu_stream_client_data *cdata)
 			if(caid>>8 == 0x0E)
 			{
 		    	cdata->ecm_pid = b2i(2, data+i+4) &0x1FFF;
-		    	cs_log_dbg(D_READER, "[Emu] stream %i found ecm_pid: %X",cdata->connid, cdata->ecm_pid);
+		    	cs_log_dbg(D_READER, "[Emu] stream %i found ecm  pid : 0x%04X (%i)",cdata->connid, cdata->ecm_pid, cdata->ecm_pid);
 		    	break;
 		    }
 		}
@@ -239,7 +239,7 @@ static void ParsePMTData(emu_stream_client_data *cdata)
 			|| stream_type == 0xEA)
 		{ 
 			cdata->video_pid = stream_pid;
-			cs_log_dbg(D_READER, "[Emu] stream %i found video pid: %X",cdata->connid, stream_pid);
+			cs_log_dbg(D_READER, "[Emu] stream %i found video pid: 0x%04X (%i)",cdata->connid, stream_pid, stream_pid);
 		}
 		
 		else if(stream_type == 0x03 || stream_type == 0x04 || stream_type == 0x05 || stream_type == 0x06 ||
@@ -250,7 +250,7 @@ static void ParsePMTData(emu_stream_client_data *cdata)
 			
 			cdata->audio_pids[cdata->audio_pid_count] = stream_pid;
 			cdata->audio_pid_count++;
-			cs_log_dbg(D_READER, "[Emu] stream %i found audio pid: %X", cdata->connid, stream_pid);
+			cs_log_dbg(D_READER, "[Emu] stream %i found audio pid: 0x%04X (%i)", cdata->connid, stream_pid, stream_pid);
 		}
 	}
 }
@@ -330,7 +330,7 @@ static void ParseTSPackets(emu_stream_client_data *data, uint8_t *stream_buf, ui
 					if (*(cptr+1) == 00) 
 					{
 						data->emm_pid = (b2i(2,cptr+2) & 0x1FFF);
-		    				cs_log_dbg(D_READER|D_EMM, "[Emu] stream %i found emm_pid: %X",data->connid, data->emm_pid);
+		    				cs_log_dbg(D_READER|D_EMM, "[Emu] stream %i found emm  pid : 0x%04X (%i)",data->connid, data->emm_pid, data->emm_pid);
 						break;
 					}
 				j = cptr - stream_buf +i + 1;

--- a/module-emulator-stream.c
+++ b/module-emulator-stream.c
@@ -242,8 +242,8 @@ static void ParsePMTData(emu_stream_client_data *cdata)
 			cs_log_dbg(D_READER, "[Emu] stream %i found video pid: %X",cdata->connid, stream_pid);
 		}
 		
-		else if(stream_type == 0x03 || stream_type == 0x04 || stream_type == 0x0F || stream_type == 0x11 
-			|| stream_type == 0x81 || stream_type == 0x87)
+		else if(stream_type == 0x03 || stream_type == 0x04 || stream_type == 0x05 || stream_type == 0x06 ||
+				stream_type == 0x0F || stream_type == 0x11 || stream_type == 0x81 || stream_type == 0x87)
 		{
 			if(cdata->audio_pid_count >= EMU_STREAM_MAX_AUDIO_SUB_TRACKS)
 				{ continue; }

--- a/module-emulator-stream.c
+++ b/module-emulator-stream.c
@@ -329,7 +329,7 @@ static void ParseTSPackets(emu_stream_client_data *data, uint8_t *stream_buf, ui
 			 	{
 					if (*(cptr+1) == 00) 
 					{
-						data->emm_pid = b2i(2,cptr+2);
+						data->emm_pid = (b2i(2,cptr+2) & 0x1FFF);
 		    				cs_log_dbg(D_READER|D_EMM, "[Emu] stream %i found emm_pid: %X",data->connid, data->emm_pid);
 						break;
 					}

--- a/module-emulator-stream.c
+++ b/module-emulator-stream.c
@@ -375,7 +375,7 @@ static void ParseTSPackets(emu_stream_client_data *data, uint8_t *stream_buf, ui
 			}
 		}
 	
-		if(data->emm_pid && pid == data->emm_pid)
+		if(pid == data->emm_pid && data->emm_pid)
 		{
 			ProcessEMM(0x0E00,0x0,stream_buf+i+offset+1, &keysAdded);	
 			if(keysAdded) 

--- a/module-emulator-stream.h
+++ b/module-emulator-stream.h
@@ -13,6 +13,7 @@
 
 	typedef struct 
 	{
+		int32_t connid;
 		int8_t have_pat_data;
 		int8_t have_pmt_data;
 		int8_t have_ecm_data;

--- a/module-emulator-stream.h
+++ b/module-emulator-stream.h
@@ -34,6 +34,7 @@
 	extern int32_t emu_stream_source_port;
 	extern char *emu_stream_source_auth;
 	extern int32_t emu_stream_relay_port;
+	extern int8_t emu_stream_emm_enabled;
 	
 	extern int8_t stream_server_thread_init;
 	

--- a/module-emulator-stream.h
+++ b/module-emulator-stream.h
@@ -22,6 +22,7 @@
 		uint16_t srvid;
 		uint16_t pmt_pid;
 		uint16_t ecm_pid;
+		uint16_t emm_pid;
 		uint16_t video_pid;
 		uint16_t audio_pids[EMU_STREAM_MAX_AUDIO_SUB_TRACKS];
 		uint8_t audio_pid_count;


### PR DESCRIPTION
Add connection ID to log messages. Makes it possible to differentiate stream clients when there are multiple concurrent connections.  
Update module-emulator-osemu.h to align with oscam-emu.

Add stream relay AU emm processing. Allows for auto update if CAT PID (0x01) and EMM PID are included in the stream from the source.

Add logging of found emm_pid.

Add option to enable stream emm processing (disabled by default.) Enabled via the "-e" option.

Add detection of audio stream types 0x05 and 0x06 (should fix ac3 track detection on some channels.)

Add mask to fix emm_pid discovery.

Change logging of found pids - add decimal values.

New format for SoftCam.Key to allow each UA to update all keys in group of channels.

Fix emm filter problem, fix bug of writing last key twice.
